### PR TITLE
Hm. reverse proxy not working on localhost through docker

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -72,6 +72,7 @@ if SENTRY_DSN is not None:
         # We recommend adjusting this value in production.
         profiles_sample_rate=1.0,
         environment="devel" if DEBUG else "production",
+        release=f"as_email_service@{VERSION}",
     )
 
 # Application definition

--- a/app/scripts/start_app.sh
+++ b/app/scripts/start_app.sh
@@ -10,4 +10,4 @@ echo "Running django migrations.."
 /venv/bin/python /app/manage.py migrate
 
 echo "Starting uvicorn.."
-/venv/bin/gunicorn config.asgi --bind 127.0.0.1:8000 --chdir=/app -w 4 -k config.uvicorn_worker.UvicornWorker
+/venv/bin/gunicorn config.asgi --bind 0.0.0.0:8000 --chdir=/app -w 4 -k config.uvicorn_worker.UvicornWorker


### PR DESCRIPTION
We have local firewall rules for off-host ports so should be safe for now. Also add release tagging for sentry.