### PR TITLE
GH-77 - test compression always enabled, offline disabled.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ COPY ./app ./
 
 RUN /venv/bin/python \
     /app/manage.py collectstatic --clear --no-input --verbosity 0
-RUN /venv/bin/python /app/manage.py compress
 
 RUN addgroup --system --gid 900 app \
     && adduser --system --uid 900 --ingroup app app
@@ -88,7 +87,6 @@ COPY ./app ./
 
 RUN /venv/bin/python \
     /app/manage.py collectstatic --clear --no-input --verbosity 0
-RUN /venv/bin/python /app/manage.py compress
 RUN /venv/bin/python /app/manage.py compile_pyc
 
 RUN addgroup --system --gid 900 app \

--- a/app/as_email/templates/as_email/base.html
+++ b/app/as_email/templates/as_email/base.html
@@ -5,7 +5,5 @@
 {% endblock defer_noncompress_js %}
 {% block defer_compress_js %}
   {{ block.super }}
-  {% compress js %}
   <script defer type="text/javascript" src="{% static 'as_email/js/base.js' %}"></script>
-  {% endcompress %}
 {% endblock defer_compress_js %}

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -305,7 +305,8 @@ LOGGING = {
 
 # Django Compressor
 #
-COMPRESS_OFFLINE = not DEBUG
+COMPRESS_ENABLED = True
+COMPRESS_OFFLINE = False
 COMPRESS_FILTERS = {
     "css": [
         "compressor.filters.css_default.CssAbsoluteFilter",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,16 +19,16 @@
       {% block extra_css %}{% endblock extra_css %}
     {% endblock css %}
     {% endcompress %}
+    {% compress js %}
     {% block defer_compress_js %}
-      {% compress js %}
       {% project_third_party_js %}
       <script defer type="text/javascript" src="{% static 'js/zxcvbn.js' %}"></script>
       <script defer type="text/javascript" src="{% static 'js/base.js' %}"></script>
-      {% endcompress %}
     {% endblock defer_compress_js %}
+    {% endcompress %}
     {% block defer_noncompress_js %}
-      <script async type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-      <script async nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
+        <script async type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+        <script async nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     {% endblock defer_noncompress_js %}
   </head>
   <body>


### PR DESCRIPTION
Also unify all our js blocks (that are not module based) so we get just one compressed js file.