### PR TITLE
GH-90: Forwarded messages are not displaying properly on the receivers side

### DIFF
--- a/app/as_email/tests/test_deliver.py
+++ b/app/as_email/tests/test_deliver.py
@@ -268,7 +268,10 @@ def test_forwarding(email_account_factory, email_factory, smtp):
     assert sent_message["Resent-To"] == ea_1.forward_to
     assert sent_message["From"] == ea_1.email_address
     assert sent_message["To"] == ea_1.forward_to
-    assert sent_message["Subject"] == f"Fwd: {original_subj}"
+    assert (
+        sent_message["Subject"]
+        == f"Fwd: forwarded from {original_from}: {original_subj}"
+    )
 
 
 ####################################################################
@@ -347,7 +350,7 @@ def test_generate_dsn(email_account_factory, email_factory):
 
 ####################################################################
 #
-def test_generate_forwarded_message(
+def test_generate_forwarded_spam_message(
     email_account_factory,
     email_factory,
     faker,
@@ -361,6 +364,7 @@ def test_generate_forwarded_message(
     )
     ea.save()
     msg = email_factory(msg_from=ea.email_address)
+    msg["X-Spam-Score"] = str(ea.spam_score_threshold + 1)
 
     forwarded_msg = make_encapsulated_fwd_msg(ea, msg)
 

--- a/app/as_email/views.py
+++ b/app/as_email/views.py
@@ -346,6 +346,9 @@ def hook_postmark_spam(request, domain_name):
             )
         ]
     ):
+        logger.warning(
+            "submitted json missing expected keys, message: %r", spam
+        )
         return HttpResponseBadRequest("submitted json missing expected keys")
 
     # Just to be safe, try to make sure that the TypeCode is an integer.


### PR DESCRIPTION
When the system forwards email it attaches the original email as an inline attachment.

It appears to be somewhat parsed in that we get the headers in but the email appears to be base64 encoded and is just a big block of letters.. sometimes parseable sometimes not.

mhshow, a paragon of ancient history, complains: mhshow:  ```message/rfc822" type in message 8614 should be encoded in 7bit or 8bit```

NOTE: closes GH-90