### PR TITLE
Remove links that go nowhere in navbar

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,28 +46,6 @@
 
         <div id="navbarBasicExample" class="navbar-menu">
           <div class="navbar-start">
-            <a class="navbar-item">
-              Documentation
-            </a>
-
-            <div class="navbar-item has-dropdown is-hoverable">
-              <a class="navbar-link">
-                More
-              </a>
-
-              <div class="navbar-dropdown">
-                <a class="navbar-item">
-                  About
-                </a>
-                <a class="navbar-item">
-                  Contact
-                </a>
-                <hr class="navbar-divider">
-                <a class="navbar-item">
-                  Report an issue
-                </a>
-              </div>
-            </div>
           </div>
 
           <div class="navbar-end">


### PR DESCRIPTION
GH-104 will cover putting these links to actual pages back in.