### PR TITLE
GH-123 - catch EmailAccount.DoesNotExist and log a warning

### DIFF
--- a/app/as_email/tasks.py
+++ b/app/as_email/tasks.py
@@ -529,7 +529,14 @@ def check_update_pwfile_for_emailaccount(ea_pk: int):
     # The password file is at the root of the maildir directory
     #
     write = False
-    ea = EmailAccount.objects.get(pk=ea_pk)
+    try:
+        ea = EmailAccount.objects.get(pk=ea_pk)
+    except EmailAccount.DoesNotExist:
+        logger.warning(
+            "Unable to find EmailAccount for pk %d. Skipping pw entry creation",
+            ea_pk,
+        )
+        return
 
     # NOTE: The path to the mail dir is relative to the directory that the
     #       password file is in. In settings the password file is always in


### PR DESCRIPTION
Fixes GH-123.

Does not fix the underlying problem. The email account should definitely exist and be saved in to the db at this time. Maybe a timing/multiple access to the sqlite db? 

However, this is not a critical issue as we can always create the external pw entry later.