### PR TITLE
GH-126 - Instead of using `send_message` that can not deal with latin -1 encoded messages, do the binary conversion ourselves.

### DIFF
--- a/app/as_email/models.py
+++ b/app/as_email/models.py
@@ -36,6 +36,10 @@ from postmarker.core import PostmarkClient
 from postmarker.exceptions import ClientError
 from requests import RequestException
 
+# project imports
+#
+from .utils import sendmail
+
 # Various models that belong to a specific user need the User object.
 #
 User = get_user_model()
@@ -316,9 +320,7 @@ class Server(models.Model):
         try:
             smtp_client.starttls()
             smtp_client.login(token, token)
-            smtp_client.send_message(
-                msg, from_addr=email_from, to_addrs=rcpt_tos
-            )
+            sendmail(smtp_client, msg, from_addr=email_from, to_addrs=rcpt_tos)
         except smtplib.SMTPException as exc:
             logger.error(
                 f"Mail from {email_from}, to: {rcpt_tos}, failed with "

--- a/app/as_email/tests/conftest.py
+++ b/app/as_email/tests/conftest.py
@@ -55,8 +55,8 @@ def assert_email_equal(msg1, msg2, ignore_headers=False):
     if ignore_headers is False:
         assert len(msg1.items()) == len(msg2.items())
         for header, value in msg1.items():
-            value = value.replace("\n", "")
-            assert msg2[header].replace("\n", "") == value
+            value = value.replace("\n", "").replace("\r", "")
+            assert msg2[header].replace("\n", "").replace("\r", "") == value
 
     # If we are ignoring only some headers, then skip those.
     #
@@ -81,7 +81,9 @@ def assert_email_equal(msg1, msg2, ignore_headers=False):
     assert len(parts1) == len(parts2)
 
     for part1, part2 in zip(parts1, parts2):
-        assert part1.get_payload() == part2.get_payload()
+        assert part1.get_payload().strip().replace("\r", "").replace(
+            "\n", ""
+        ) == part2.get_payload().strip().replace("\r", "").replace("\n", "")
 
 
 ####################################################################

--- a/app/as_email/tests/test_deliver.py
+++ b/app/as_email/tests/test_deliver.py
@@ -5,11 +5,14 @@ Test the various functions in the `deliver` module
 """
 # system imports
 #
+import email
+import email.message
 
 # 3rd party imports
 #
 import factory
 import pytest
+from dirty_equals import Contains
 
 # Project imports
 #
@@ -255,13 +258,17 @@ def test_forwarding(email_account_factory, email_factory, smtp):
     #       called with the appropriate values.
     #
     send_message = smtp.return_value.send_message
+    send_message = smtp.return_value.sendmail
     assert send_message.call_count == 1
-    assert send_message.call_args.kwargs == {
-        "from_addr": ea_1.email_address,
-        "to_addrs": [ea_1.forward_to],
-    }
+    assert send_message.call_args.args == Contains(
+        ea_1.email_address,
+        [ea_1.forward_to],
+    )
 
-    sent_message = send_message.call_args.args[0]
+    sent_message_bytes = send_message.call_args.args[2]
+    sent_message = email.message_from_bytes(
+        sent_message_bytes, policy=email.policy.default
+    )
     assert sent_message["Original-From"] == original_from
     assert sent_message["Original-Recipient"] == ea_1.email_address
     assert sent_message["Resent-From"] == ea_1.email_address

--- a/app/as_email/tests/test_tasks.py
+++ b/app/as_email/tests/test_tasks.py
@@ -10,6 +10,7 @@ from datetime import datetime
 # 3rd party imports
 #
 import pytest
+from dirty_equals import Contains
 
 # Project imports
 #
@@ -44,12 +45,12 @@ def test_dispatch_spool_outgoing_email(
     spool_message(server.outgoing_spool_dir, msg.as_bytes())
     res = dispatch_spooled_outgoing_email()
     res()
-    send_message = smtp.return_value.send_message
+    send_message = smtp.return_value.sendmail
     assert send_message.call_count == 1
-    assert send_message.call_args.kwargs == {
-        "from_addr": from_addr,
-        "to_addrs": rcpt_tos,
-    }
+    assert send_message.call_args.args == Contains(
+        from_addr,
+        rcpt_tos,
+    )
 
 
 ####################################################################


### PR DESCRIPTION
B-( as usual the internet gives us messages that are a bit off from what the generic path in python for parsing messages expects.

Brute for this by using our own BinaryGenerator.. if it fails to encode with `ascii` then leap straight to `latin-1`

Hopefully this handles all the weird cases (it might not, but we will fix that when it happens.)

This fixes GH-126.