### PR TITLE
GH-121-need-to-search-fields-on-admin-no-foreign-keys

### DIFF
--- a/app/as_email/admin.py
+++ b/app/as_email/admin.py
@@ -85,7 +85,10 @@ class EmailAccountAdmin(admin.ModelAdmin):
         "modified_at",
     )
     search_fields = (
-        "owner",
+        "owner__username",
+        "owner__email",
+        "owner__first_name",
+        "owner__last_name",
         "email_address",
     )
     inlines = [


### PR DESCRIPTION
When searching in the admin we need to specify the _fields_ to search on. Now just the foreign key.. so we need to specify which fields attached to the foreign key we want to search on.