### PR TITLE
GH-149: Move failed incoming deliveries to their own directory.

### DIFF
--- a/app/as_email/deliver.py
+++ b/app/as_email/deliver.py
@@ -74,6 +74,10 @@ def deliver_message(
                 deliver_message(alias_for, msg, depth + 1)
         case EmailAccount.FORWARDING:
             forward_message(email_account, msg)
+        case _:
+            raise RuntimeError(
+                f"Unknown delivery method {email_account.delivery_method}"
+            )
 
 
 ####################################################################

--- a/app/as_email/tests/conftest.py
+++ b/app/as_email/tests/conftest.py
@@ -204,6 +204,10 @@ def email_spool_dir(settings, tmp_path):
     spool_dir = tmp_path / "spool"
     spool_dir.mkdir(parents=True, exist_ok=True)
     settings.EMAIL_SPOOL_DIR = spool_dir
+    settings.FAILED_INCOMING_MSG_DIR = (
+        settings.EMAIL_SPOOL_DIR / "failed_incoming"
+    )
+    settings.FAILED_INCOMING_MSG_DIR.mkdir(parents=True, exist_ok=True)
     yield spool_dir
 
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -78,7 +78,6 @@ env = environ.FileAwareEnv(
 # services at `https`
 #
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
 # NOTE: We should try moving secrets to compose secrets.
 #
 DEBUG = env("DEBUG")
@@ -280,6 +279,7 @@ EMAIL_SERVER_TOKENS = env.dict("EMAIL_SERVER_TOKENS")
 # directory there will be an "incoming" and "outgoing" directory.
 #
 EMAIL_SPOOL_DIR = Path(env("EMAIL_SPOOL_DIR"))
+FAILED_INCOMING_MSG_DIR = EMAIL_SPOOL_DIR / "failed_incoming"
 
 # This is the parent directory where all the MH mail dirs are for all the email
 # accounts. There will be a subdir for each server, and a dir with the username


### PR DESCRIPTION
This does not solve the problem but lets us capture failed emails. This lets us eventually re-deliver them, and lets us examine them to see why they failed.