### PR TITLE
GH-156: Retry on FileExistsError

### DIFF
--- a/app/as_email/deliver.py
+++ b/app/as_email/deliver.py
@@ -148,7 +148,7 @@ def lock_folder(
         try:
             folder.lock()
             break
-        except ExternalClashError:
+        except (ExternalClashError, FileExistsError):
             if fail:
                 raise
             timeout -= 0.1


### PR DESCRIPTION
Race condition on dot-locking MH folder. Looking at the mailbox.py source the state seems to be safe to treat as if the lock failed due to a clash.

Fixes GH-156
