### PR TITLE
Support selectively enabling or disabling listening for SMTP as well as submission ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for disabling SMTP ports in aiosmtpd daemon by specifying "off" for `--submission_port` or `--smtp_port` arguments, allowing flexible port configuration
+
 ## [0.1.5 - 2023-11-28]
 
 ### Updated

--- a/app/as_email/__init__.py
+++ b/app/as_email/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 __authors__ = ["Scanner Luce <scanner@apricot.com>"]

--- a/app/scripts/start_smtpd.sh
+++ b/app/scripts/start_smtpd.sh
@@ -9,7 +9,7 @@ wait-for-it --service spamassassin:783 -- echo "SpamAssassin available"
 
 : "${SMTPD_LISTEN_HOST:=0.0.0.0}"
 : "${SMTPD_SUBMISSION_PORT:=587}"
-: "${SMTPD_SMTP_PORT:=25}"
+: "${SMTPD_SMTP_PORT:=off}"
 : "${SMTPD_CERT:=/mnt/ssl/ssl_crt.pem}"
 : "${SMTPD_KEY:=/mnt/ssl/ssl_key.pem}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,6 @@ services:
       dockerfile: ./Dockerfile
       target: dev
     ports:
-      - "25:25"
       - "587:587"
     command: /app/scripts/start_smtpd.sh
     restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "as-email-service"
-version = "0.2.6"
+version = "0.2.7"
 description = "Apricot Systematic Email Service"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "as-email-service"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Basically we want to selectively enable if we listen on port 25, so we can specify the port as "off" and aiosmtpd will not start that listener.