### PR TITLE
Fix signal handler signature in email_account_pre_save

### DIFF
--- a/app/as_email/signals.py
+++ b/app/as_email/signals.py
@@ -40,7 +40,9 @@ logger = logging.getLogger("as_email.models")
 ####################################################################
 #
 @receiver(pre_save, sender=EmailAccount)
-def email_account_pre_save() -> None:
+def email_account_pre_save(
+    sender: Type[EmailAccount], instance: EmailAccount, **kwargs
+) -> None:
     """
     Conduct pre-save EmailAccount actions, like creating the various
     folders associated with this EmailAccount


### PR DESCRIPTION
The email_account_pre_save() pre_save signal handler was missing required parameters (sender, instance, **kwargs), causing a TypeError when Django tried to invoke it.

Fixed by adding the standard signal handler parameters to match the signature expected by Django's signal dispatcher.

All tests in test_models.py now pass.