### PR TITLE
Use FieldTracker to detect mail_dir changes in pre_save signal

### DIFF
--- a/app/as_email/models.py
+++ b/app/as_email/models.py
@@ -681,7 +681,7 @@ class EmailAccount(models.Model):
     # We want to track when certain fields change so we can do additional
     # operations that only need to happen when those fields change.
     #
-    tracker = FieldTracker(fields=["password"])
+    tracker = FieldTracker(fields=["password", "mail_dir"])
 
     class Meta:
         # If an EmailAccount has the permission "can_have_foreign_aliases" then


### PR DESCRIPTION
Instead of fetching the old EmailAccount instance from the database in the emailaccount_pre_save signal, use the existing FieldTracker to detect changes to the mail_dir field. This is more efficient and follows the pattern already established for the password field.

Changes:
- Add mail_dir to FieldTracker fields in EmailAccount model
- Replace database fetch with tracker.has_changed("mail_dir") call
- Remove unnecessary try/except block for database lookup