### PR TITLE
Default catch_all alias off. Fix email account -> alias to be full sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `sync_provider_aliases` management command re-pushes alias settings (including webhook URLs) to all configured providers — useful after changing `SITE_NAME`
+- `ProviderName` StrEnum in the provider package enumerates all registered backend names
+- `ForwardEmailBackend.DEFAULT_ALIAS_SETTINGS` class attribute documents and enforces desired per-alias configuration, mirroring the existing `DEFAULT_DOMAIN_SETTINGS` pattern
+
+### Changed
+
+- GH-196: `ForwardEmailBackend.create_update_domain()` now fetches the live domain, diffs it against `DEFAULT_DOMAIN_SETTINGS`, and issues a PUT only for fields that have drifted; no-op when settings are already correct
+- `ForwardEmailBackend.create_update_email_account()` applies the same idempotent GET → diff → conditional PUT pattern using `DEFAULT_ALIAS_SETTINGS`
+- Provider admin: `backend_name` is now a dropdown of registered backends instead of a free-text field
+- Provider admin: SMTP server configuration split into separate host and port fields; port accepts any valid port (1–65535, default 25); receive-only providers no longer require an SMTP host
+
 ## [0.4.0] - 2026-02-25
 
 ### Added

--- a/app/as_email/providers/forwardemail.py
+++ b/app/as_email/providers/forwardemail.py
@@ -566,20 +566,20 @@ class ForwardEmailBackend(ProviderBackend):
     #                                  because a hard 554 reject is too aggressive
     #   has_executable_protection  -- rejects executable attachments; False because
     #                                  legitimate mail sometimes carries executables
-    #   has_catchall               -- False; unknown addresses should bounce, not be
-    #                                  silently absorbed by a catch-all
     #   retention_days             -- outbound SMTP log retention (0–30 days);
     #                                  relevant once we add sending support
     #
     # NOTE: `plan` is intentionally excluded -- it is managed via the
     #       forwardemail.net website and must never be overwritten by code.
+    # NOTE: `catchall` is intentionally excluded -- it is only accepted at
+    #       domain creation time (POST), not on updates (PUT).  It is passed
+    #       separately in create_update_domain() when creating a new domain.
     #
     DEFAULT_DOMAIN_SETTINGS: dict[str, Any] = {
         "has_adult_content_protection": False,
         "has_phishing_protection": True,
         "has_executable_protection": False,
         "has_virus_protection": True,
-        "has_catchall": False,
         "has_delivery_logs": True,
         "retention_days": 7,
     }
@@ -1013,8 +1013,13 @@ class ForwardEmailBackend(ProviderBackend):
             pass
 
         # Create the domain with our desired settings.
+        # NOTE: `catchall` is a create-only field; it cannot be set via PUT.
         #
-        data = {"domain": server.domain_name, **self.DEFAULT_DOMAIN_SETTINGS}
+        data = {
+            "domain": server.domain_name,
+            "catchall": False,
+            **self.DEFAULT_DOMAIN_SETTINGS,
+        }
         r = self.api.req(HTTPMethod.POST, "v1/domains", data=data)
         domain_info = r.json()
         self.cache.set_domain(domain_info)

--- a/app/as_email/signals.py
+++ b/app/as_email/signals.py
@@ -38,7 +38,7 @@ from .tasks import (
     provider_create_email_account,
     provider_create_server,
     provider_delete_email_account,
-    provider_enable_email_accounts_for_server,
+    provider_sync_server_aliases,
 )
 
 User = get_user_model()
@@ -286,14 +286,14 @@ def handle_receive_providers_changed(
     """
     match action:
         case "post_add":
-            # Provider(s) added to server - register server then enable email accounts
+            # Provider(s) added to server - register server then sync aliases
             for provider_pk in pk_set:
                 provider = Provider.objects.get(pk=provider_pk)
-                # Chain tasks: register server first, then enable email accounts
+                # Chain tasks: register server first, then sync aliases
                 pipeline = provider_create_server.s(
                     instance.pk, provider.backend_name
                 ).then(
-                    provider_enable_email_accounts_for_server,
+                    provider_sync_server_aliases,
                     instance.pk,
                     provider.backend_name,
                     True,
@@ -301,10 +301,9 @@ def handle_receive_providers_changed(
                 HUEY.enqueue(pipeline)
 
         case "post_remove":
-            # Provider(s) removed from server - disable email accounts
+            # Provider(s) removed from server - delete all aliases on the provider
             for provider_pk in pk_set:
                 provider = Provider.objects.get(pk=provider_pk)
-                # Disable all email accounts for this server on the provider
-                provider_enable_email_accounts_for_server(
+                provider_sync_server_aliases(
                     instance.pk, provider.backend_name, enabled=False
                 )

--- a/app/as_email/tasks.py
+++ b/app/as_email/tasks.py
@@ -751,39 +751,33 @@ def provider_delete_email_account(
 ####################################################################
 #
 @db_task(retries=3, retry_delay=10)
-def provider_enable_email_accounts_for_server(
+def provider_sync_server_aliases(
     server_pk: int, provider_name: str, enabled: bool
 ) -> None:
     """
-    Enable or disable all email accounts for a server on the specified provider.
+    Bidirectional alias sync between local EmailAccounts and a provider.
 
-    This task fetches the current state of all email accounts from the provider,
-    compares with local EmailAccounts, and only updates those that need changing.
-    It will also create any missing email accounts.
+    When enabled=True (normal sync, e.g. hourly or on provider add):
+      - Creates aliases on the provider for any local EmailAccount that is missing
+      - Deletes aliases on the provider that have no corresponding local EmailAccount
+        (catches catch-all aliases, manually-created strays, leftovers from
+        deleted EmailAccounts, etc.)
+      - Enables any alias that is currently disabled on the provider
 
-    This task is triggered when:
-    - Provider is added to Server's receive_providers (enabled=True)
-    - Provider is removed from Server's receive_providers (enabled=False)
+    When enabled=False (provider removed from server's receive_providers):
+      - Deletes ALL aliases for this server from the provider (clean slate)
 
     Args:
         server_pk: Primary key of the Server instance
         provider_name: Name of the provider backend (e.g., 'forwardemail',
                        'postmark')
-        enabled: True to enable email accounts, False to disable them
+        enabled: True for normal sync; False to delete all remote aliases
     """
     server = Server.objects.get(pk=server_pk)
     backend = get_backend(provider_name)
 
-    # Get all EmailAccounts for this server
+    # Fetch all existing aliases from the provider.
     #
-    # NOTE: This obviously does not scale if you have thousands and thousands
-    # of email accounts. We likely need to do both fetches from django and from
-    # the provider in parallel using generators.
-    #
-    email_accounts = EmailAccount.objects.filter(server=server)
-    local_addresses = {ea.email_address: ea for ea in email_accounts}
-
-    # Fetch all existing email accounts from the provider
     try:
         remote_email_accounts = backend.list_email_accounts(server)
     except Exception as e:
@@ -795,65 +789,126 @@ def provider_enable_email_accounts_for_server(
         )
         raise
 
-    # Build a map of remote email accounts by their email address
-    #
     remote_map = {ea.email: ea for ea in remote_email_accounts}
 
+    if not enabled:
+        # Provider removed from server: delete every remote alias (clean slate).
+        #
+        deleted_count = 0
+        error_count = 0
+        for email_addr in list(remote_map.keys()):
+            try:
+                backend.delete_email_account_by_address(email_addr, server)
+                deleted_count += 1
+                logger.info(
+                    "Deleted email account '%s' from provider '%s' (provider removed)",
+                    email_addr,
+                    provider_name,
+                )
+            except Exception as e:
+                error_count += 1
+                logger.exception(
+                    "Failed to delete email account '%s' on provider '%s': %r",
+                    email_addr,
+                    provider_name,
+                    e,
+                )
+        logger.info(
+            "Provider removal sync for server '%s' on provider '%s': "
+            "%d deleted, %d errors",
+            server.domain_name,
+            provider_name,
+            deleted_count,
+            error_count,
+        )
+        return
+
+    # enabled=True: full bidirectional sync.
+    #
+    email_accounts = EmailAccount.objects.filter(server=server)
+    local_map = {ea.email_address: ea for ea in email_accounts}
+    local_set = set(local_map.keys())
+    remote_set = set(remote_map.keys())
+
+    to_create = local_set - remote_set  # missing on provider → create
+    to_delete = remote_set - local_set  # orphaned on provider → delete
+    to_check = local_set & remote_set  # present on both → ensure enabled
+
     created_count = 0
+    deleted_count = 0
     updated_count = 0
     skipped_count = 0
     error_count = 0
 
-    # Process each local EmailAccount
-    for email_addr, email_account in local_addresses.items():
+    for email_addr in to_create:
         try:
-            if email_addr not in remote_map:
-                # Email account doesn't exist on provider, create it
-                backend.create_email_account(email_account)
-                created_count += 1
-                logger.info(
-                    "Created missing email account '%s' on provider '%s'",
+            backend.create_email_account(local_map[email_addr])
+            created_count += 1
+            logger.info(
+                "Created missing email account '%s' on provider '%s'",
+                email_addr,
+                provider_name,
+            )
+        except Exception as e:
+            error_count += 1
+            logger.exception(
+                "Failed to create email account '%s' on provider '%s': %r",
+                email_addr,
+                provider_name,
+                e,
+            )
+
+    for email_addr in to_delete:
+        try:
+            backend.delete_email_account_by_address(email_addr, server)
+            deleted_count += 1
+            logger.info(
+                "Deleted orphaned alias '%s' from provider '%s'",
+                email_addr,
+                provider_name,
+            )
+        except Exception as e:
+            error_count += 1
+            logger.exception(
+                "Failed to delete orphaned alias '%s' on provider '%s': %r",
+                email_addr,
+                provider_name,
+                e,
+            )
+
+    for email_addr in to_check:
+        try:
+            if not remote_map[email_addr].enabled:
+                backend.enable_email_account(
+                    local_map[email_addr], enabled=True
+                )
+                updated_count += 1
+                logger.debug(
+                    "Enabled email account '%s' on provider '%s'",
                     email_addr,
                     provider_name,
                 )
             else:
-                # Email account exists, check if enabled needs updating
-                remote_email_account = remote_map[email_addr]
-                remote_enabled = remote_email_account.enabled
-
-                if remote_enabled != enabled:
-                    # Need to update enabled flag
-                    backend.enable_email_account(email_account, enabled=enabled)
-                    updated_count += 1
-                    logger.debug(
-                        "Updated enabled=%s for email account '%s' on provider '%s'",
-                        enabled,
-                        email_addr,
-                        provider_name,
-                    )
-                else:
-                    # Already in correct state, skip
-                    skipped_count += 1
-
+                skipped_count += 1
         except Exception as e:
             error_count += 1
             logger.exception(
-                "Failed to process email account '%s' on provider '%s': %r",
+                "Failed to enable email account '%s' on provider '%s': %r",
                 email_addr,
                 provider_name,
                 e,
             )
 
     logger.info(
-        "Bulk email account sync for server '%s' on provider '%s': "
-        "%d created, %d updated, %d skipped, %d errors (target enabled=%s)",
+        "Alias sync for server '%s' on provider '%s': "
+        "%d created, %d deleted, %d enabled, %d skipped, %d errors",
         server.domain_name,
         provider_name,
         created_count,
+        deleted_count,
         updated_count,
         skipped_count,
         error_count,
-        enabled,
     )
 
 
@@ -887,9 +942,7 @@ def provider_sync_email_accounts() -> None:
 
         for server in servers_with_provider:
             try:
-                # Use the same logic as provider_enable_email_accounts_for_server
-                # to sync all email accounts for this server (target: enabled=True)
-                provider_enable_email_accounts_for_server(
+                provider_sync_server_aliases(
                     server.pk, provider.backend_name, enabled=True
                 )
             except Exception as e:

--- a/app/as_email/tests/test_signals.py
+++ b/app/as_email/tests/test_signals.py
@@ -220,7 +220,7 @@ class TestProviderSignals:
 
     ####################################################################
     #
-    def test_handle_receive_providers_changed_post_remove_disables_email_accounts(
+    def test_handle_receive_providers_changed_post_remove_deletes_aliases(
         self,
         server_factory: Callable[..., Server],
         mocker: MockerFixture,
@@ -228,24 +228,24 @@ class TestProviderSignals:
         """
         GIVEN: a server with one receive provider
         WHEN:  that provider is removed from server.receive_providers
-        THEN:  provider_enable_email_accounts_for_server is called with enabled=False
+        THEN:  provider_sync_server_aliases is called with enabled=False
         """
         server = server_factory()
         provider = server.receive_providers.first()
 
-        mock_enable = mocker.patch(
-            "as_email.signals.provider_enable_email_accounts_for_server"
+        mock_sync = mocker.patch(
+            "as_email.signals.provider_sync_server_aliases"
         )
 
         server.receive_providers.remove(provider)
 
-        mock_enable.assert_called_once_with(
+        mock_sync.assert_called_once_with(
             server.pk, provider.backend_name, enabled=False
         )
 
     ####################################################################
     #
-    def test_handle_receive_providers_changed_post_remove_disables_email_accounts_per_provider(
+    def test_handle_receive_providers_changed_post_remove_deletes_aliases_per_provider(
         self,
         server_factory: Callable[..., Server],
         provider_factory: Callable[..., Provider],
@@ -254,22 +254,21 @@ class TestProviderSignals:
         """
         GIVEN: a server with two receive providers
         WHEN:  both providers are removed from server.receive_providers in one call
-        THEN:  provider_enable_email_accounts_for_server is called once per provider
-               with enabled=False
+        THEN:  provider_sync_server_aliases is called once per provider with enabled=False
         """
         server = server_factory()
         second_provider = provider_factory()
         server.receive_providers.add(second_provider)
 
-        mock_enable = mocker.patch(
-            "as_email.signals.provider_enable_email_accounts_for_server"
+        mock_sync = mocker.patch(
+            "as_email.signals.provider_sync_server_aliases"
         )
 
         providers = list(server.receive_providers.all())
         server.receive_providers.remove(*providers)
 
-        assert mock_enable.call_count == 2
+        assert mock_sync.call_count == 2
         for provider in providers:
-            mock_enable.assert_any_call(
+            mock_sync.assert_any_call(
                 server.pk, provider.backend_name, enabled=False
             )

--- a/app/as_email/tests/test_tasks.py
+++ b/app/as_email/tests/test_tasks.py
@@ -36,9 +36,9 @@ from ..tasks import (
     provider_create_email_account,
     provider_create_server,
     provider_delete_email_account,
-    provider_enable_email_accounts_for_server,
     provider_report_unused_servers,
     provider_sync_email_accounts,
+    provider_sync_server_aliases,
     retry_failed_incoming_email,
 )
 from ..utils import (
@@ -1070,12 +1070,12 @@ class TestProviderDeleteAlias:
 ########################################################################
 ########################################################################
 #
-class TestProviderEnableAllAliases:
-    """Tests for provider_enable_email_accounts_for_server task."""
+class TestProviderSyncServerAliases:
+    """Tests for provider_sync_server_aliases task."""
 
     ####################################################################
     #
-    def test_enable_all_aliases_creates_missing(
+    def test_creates_missing_aliases(
         self,
         mocker: MockerFixture,
         server_factory,
@@ -1085,7 +1085,7 @@ class TestProviderEnableAllAliases:
     ) -> None:
         """
         Given a server with email accounts but missing aliases on provider
-        When provider_enable_email_accounts_for_server is called
+        When provider_sync_server_aliases is called with enabled=True
         Then missing aliases should be created
         """
         server = server_factory(send_provider=None, receive_providers=[])
@@ -1093,7 +1093,7 @@ class TestProviderEnableAllAliases:
         ea2 = email_account_factory(server=server)
         email_accounts = sorted((ea1, ea2), key=lambda x: x.email_address)
 
-        res = provider_enable_email_accounts_for_server(
+        res = provider_sync_server_aliases(
             server.pk,
             dummy_provider.PROVIDER_NAME,
             enabled=True,
@@ -1109,7 +1109,7 @@ class TestProviderEnableAllAliases:
 
     ####################################################################
     #
-    def test_enable_all_aliases_updates_existing(
+    def test_enables_disabled_aliases(
         self,
         mocker: MockerFixture,
         server_factory,
@@ -1117,42 +1117,31 @@ class TestProviderEnableAllAliases:
         dummy_provider: DummyProviderBackend,
     ) -> None:
         """
-        Given aliases that exist but have wrong is_enabled state
-        When provider_enable_email_accounts_for_server is called
-        Then aliases should be updated
+        Given aliases that exist but are disabled on the provider
+        When provider_sync_server_aliases is called with enabled=True
+        Then aliases should be enabled
         """
         server = server_factory()
-
-        # Create the email accounts, since we did not specify providers when
-        # creating the server via the factory it used the dummy backend. By
-        # creating these email accounts they will be created in the provider
-        # backend (and enabled)
-        #
         email_accounts = [
             email_account_factory(server=server) for _ in range(3)
         ]
         for ea in email_accounts:
             dummy_provider.enable_email_account(ea, enabled=False)
 
-        # To make sure they got disabled check the backend..
-        #
         for ea in dummy_provider.list_email_accounts(server):
             assert ea.enabled is False
 
-        res = provider_enable_email_accounts_for_server(
+        res = provider_sync_server_aliases(
             server.pk, dummy_provider.PROVIDER_NAME, enabled=True
         )
         res()
 
-        # Go through each email account, and check its state. They should all
-        # be enabled now.
-        #
         for ea in dummy_provider.list_email_accounts(server):
             assert ea.enabled is True
 
     ####################################################################
     #
-    def test_enable_all_aliases_skips_correct_state(
+    def test_skips_already_correct_aliases(
         self,
         mocker: MockerFixture,
         server_factory,
@@ -1160,8 +1149,9 @@ class TestProviderEnableAllAliases:
         provider_factory,
     ) -> None:
         """
-        Given aliases already in correct is_enabled state When
-        provider_enable_email_accounts_for_server is called Then aliases should be skipped
+        Given aliases already enabled on the provider
+        When provider_sync_server_aliases is called with enabled=True
+        Then no create, enable, or delete calls should be made
         """
         provider = provider_factory(backend_name="dummy")
         server = server_factory()
@@ -1170,7 +1160,6 @@ class TestProviderEnableAllAliases:
         ea1 = email_account_factory(server=server)
         mailbox_name = ea1.email_address.split("@")[0]
 
-        # Mock backend to return alias that is already enabled
         mock_backend = mocker.Mock()
         mock_backend.list_email_accounts.return_value = [
             EmailAccountInfo(
@@ -1186,18 +1175,18 @@ class TestProviderEnableAllAliases:
             return_value=mock_backend,
         )
 
-        res = provider_enable_email_accounts_for_server(
+        res = provider_sync_server_aliases(
             server.pk, provider.backend_name, enabled=True
         )
         res()
 
-        # Verify no changes were made
-        mock_backend.create_update_email_account.assert_not_called()
+        mock_backend.create_email_account.assert_not_called()
         mock_backend.enable_email_account.assert_not_called()
+        mock_backend.delete_email_account_by_address.assert_not_called()
 
     ####################################################################
     #
-    def test_enable_all_aliases_mixed_operations(
+    def test_deletes_orphaned_aliases(
         self,
         mocker: MockerFixture,
         server_factory,
@@ -1205,26 +1194,80 @@ class TestProviderEnableAllAliases:
         provider_factory,
     ) -> None:
         """
-        Given a mix of enabled, disabled, and missing email accounts from the backend
-        When `provider_enable_email_accounts_for_server` is called
-        Then disabled accounts should be enabled, missing accounts created
+        Given aliases on the provider with no corresponding local EmailAccount
+        (e.g. catch-all "*", or leftovers from deleted accounts)
+        When provider_sync_server_aliases is called with enabled=True
+        Then orphaned aliases should be deleted
         """
         provider = provider_factory(backend_name="dummy")
         server = server_factory()
         server.receive_providers.add(provider)
 
-        ea1 = email_account_factory(server=server)  # Will need to be created
-        ea2 = email_account_factory(server=server)  # Needs update
-        ea3 = email_account_factory(server=server)  # Already correct
+        ea1 = email_account_factory(server=server)
+        mailbox1 = ea1.email_address.split("@")[0]
+
+        # Provider has ea1 plus a stray catch-all with no local counterpart
+        catchall_email = f"*@{server.domain_name}"
+        mock_backend = mocker.Mock()
+        mock_backend.list_email_accounts.return_value = [
+            EmailAccountInfo(
+                id=f"dummy-{mailbox1}",
+                email=ea1.email_address,
+                domain=server.domain_name,
+                enabled=True,
+                name=mailbox1,
+            ),
+            EmailAccountInfo(
+                id="dummy-catchall",
+                email=catchall_email,
+                domain=server.domain_name,
+                enabled=True,
+                name="*",
+            ),
+        ]
+        mocker.patch(
+            "as_email.tasks.get_backend",
+            return_value=mock_backend,
+        )
+
+        res = provider_sync_server_aliases(
+            server.pk, provider.backend_name, enabled=True
+        )
+        res()
+
+        mock_backend.delete_email_account_by_address.assert_called_once_with(
+            catchall_email, server
+        )
+        mock_backend.create_email_account.assert_not_called()
+        mock_backend.enable_email_account.assert_not_called()
+
+    ####################################################################
+    #
+    def test_mixed_operations(
+        self,
+        mocker: MockerFixture,
+        server_factory,
+        email_account_factory,
+        provider_factory,
+    ) -> None:
+        """
+        Given a mix of missing, disabled, correct, and orphaned aliases
+        When provider_sync_server_aliases is called with enabled=True
+        Then: missing are created, disabled are enabled, orphans are deleted,
+              correct are skipped
+        """
+        provider = provider_factory(backend_name="dummy")
+        server = server_factory()
+        server.receive_providers.add(provider)
+
+        ea1 = email_account_factory(server=server)  # missing from provider
+        ea2 = email_account_factory(server=server)  # disabled on provider
+        ea3 = email_account_factory(server=server)  # already enabled
 
         mailbox2 = ea2.email_address.split("@")[0]
         mailbox3 = ea3.email_address.split("@")[0]
+        catchall_email = f"*@{server.domain_name}"
 
-        # All the backends have the same methods. We are testing that this task
-        # will properly take the list of email accounts that the backend
-        # returns from `list_email_accounts` and issue commands to set them all
-        # to enabled.
-        #
         mock_backend = mocker.Mock()
         mock_backend.list_email_accounts.return_value = [
             EmailAccountInfo(
@@ -1233,36 +1276,98 @@ class TestProviderEnableAllAliases:
                 domain=server.domain_name,
                 enabled=False,
                 name=mailbox2,
-            ),  # Wrong state
+            ),
             EmailAccountInfo(
                 id=f"dummy-{mailbox3}",
                 email=ea3.email_address,
                 domain=server.domain_name,
                 enabled=True,
                 name=mailbox3,
-            ),  # Correct state
+            ),
+            EmailAccountInfo(
+                id="dummy-catchall",
+                email=catchall_email,
+                domain=server.domain_name,
+                enabled=True,
+                name="*",
+            ),
         ]
         mocker.patch(
             "as_email.tasks.get_backend",
             return_value=mock_backend,
         )
 
-        # Call the huey task. Remember in tests all huey tasks execute in
-        # immediate mode.
-        #
-        res = provider_enable_email_accounts_for_server(
+        res = provider_sync_server_aliases(
             server.pk, provider.backend_name, enabled=True
         )
         res()
 
-        # Verify operations
-        # ea1 should be created (not in backend list)
         mock_backend.create_email_account.assert_called_once_with(ea1)
-        # ea2 should be enabled (in backend list but wrong state)
         mock_backend.enable_email_account.assert_called_once_with(
             ea2, enabled=True
         )
-        # ea3 should not be touched (already in correct state)
+        mock_backend.delete_email_account_by_address.assert_called_once_with(
+            catchall_email, server
+        )
+
+    ####################################################################
+    #
+    def test_enabled_false_deletes_all_aliases(
+        self,
+        mocker: MockerFixture,
+        server_factory,
+        email_account_factory,
+        provider_factory,
+    ) -> None:
+        """
+        Given a server with aliases on the provider
+        When provider_sync_server_aliases is called with enabled=False
+        Then all remote aliases should be deleted (provider removed from server)
+        """
+        provider = provider_factory(backend_name="dummy")
+        server = server_factory()
+        server.receive_providers.add(provider)
+
+        ea1 = email_account_factory(server=server)
+        ea2 = email_account_factory(server=server)
+        mailbox1 = ea1.email_address.split("@")[0]
+        mailbox2 = ea2.email_address.split("@")[0]
+
+        mock_backend = mocker.Mock()
+        mock_backend.list_email_accounts.return_value = [
+            EmailAccountInfo(
+                id=f"dummy-{mailbox1}",
+                email=ea1.email_address,
+                domain=server.domain_name,
+                enabled=True,
+                name=mailbox1,
+            ),
+            EmailAccountInfo(
+                id=f"dummy-{mailbox2}",
+                email=ea2.email_address,
+                domain=server.domain_name,
+                enabled=True,
+                name=mailbox2,
+            ),
+        ]
+        mocker.patch(
+            "as_email.tasks.get_backend",
+            return_value=mock_backend,
+        )
+
+        res = provider_sync_server_aliases(
+            server.pk, provider.backend_name, enabled=False
+        )
+        res()
+
+        assert mock_backend.delete_email_account_by_address.call_count == 2
+        deleted_addresses = {
+            call.args[0]
+            for call in mock_backend.delete_email_account_by_address.call_args_list
+        }
+        assert deleted_addresses == {ea1.email_address, ea2.email_address}
+        mock_backend.create_email_account.assert_not_called()
+        mock_backend.enable_email_account.assert_not_called()
 
 
 ########################################################################
@@ -1285,7 +1390,7 @@ class TestProviderSyncAliases:
         """
         Given multiple providers with multiple servers
         When provider_sync_email_accounts is called
-        Then provider_enable_email_accounts_for_server should be called for all servers
+        Then provider_sync_server_aliases should be called for all servers
         """
         provider1 = provider_factory(backend_name="dummy")
         provider2 = provider_factory(backend_name="dummy")
@@ -1296,34 +1401,23 @@ class TestProviderSyncAliases:
         server4 = server_factory(receive_providers=[provider2])
 
         # We actually do not need any email address because we are going to
-        # mock the underlying function `provider_enable_email_accounts_for_server_for_server`
-        # and see that it is called. Testing _that_ task is a separate test
-        # from this one.
+        # mock the underlying provider_sync_server_aliases task and verify it
+        # is called. Testing _that_ task is a separate test from this one.
         #
         for server in (server1, server2, server3, server4):
             email_account_factory(server=server)
             email_account_factory(server=server)
 
-        # mock the `provider_enable_all_alises` task that will be called once
-        # for each server. We are doing it after the above factories because
-        # they will also call this task when setting up the intial aliases.
+        # Mock provider_sync_server_aliases after the factories run so we only
+        # capture the calls from the periodic task under test.
         #
-        provider_enable_email_accounts_for_server_mock = mocker.patch(
-            "as_email.tasks.provider_enable_email_accounts_for_server"
-        )
+        mock_sync = mocker.patch("as_email.tasks.provider_sync_server_aliases")
         res = provider_sync_email_accounts()
         res()
 
-        # Verify provider_enable_email_accounts_for_server was called once for each server.
-        #
-        assert provider_enable_email_accounts_for_server_mock.call_count == 4
+        assert mock_sync.call_count == 4
 
-        # Verify it was called with each server exactly once
-        #
-        called_server_ids = {
-            call[0][0]
-            for call in provider_enable_email_accounts_for_server_mock.call_args_list
-        }
+        called_server_ids = {call[0][0] for call in mock_sync.call_args_list}
         expected_server_ids = {server1.pk, server2.pk, server3.pk, server4.pk}
         assert called_server_ids == expected_server_ids
 
@@ -1356,10 +1450,9 @@ class TestProviderSyncAliases:
             side_effect=get_backend_side_effect,
         )
 
-        # Mock provider_enable_email_accounts_for_server
         mock_enable_task = mocker.Mock()
         mocker.patch(
-            "as_email.tasks.provider_enable_email_accounts_for_server",
+            "as_email.tasks.provider_sync_server_aliases",
             return_value=mock_enable_task,
         )
 


### PR DESCRIPTION
When a domain is created on forwardemail.net without explicitly disabling the
catch-all, an alias with ~name: "*"~ and label ~"catch-all"~ is created that
forwards all unmatched addresses to a configured recipient. This is not wanted
— unrecognised addresses should be refused or silently dropped.

*Resolved by two changes:*

1. *~create_update_domain()~ fix*: ~DEFAULT_DOMAIN_SETTINGS~ contained
   ~has_catchall: False~ which was the wrong key name and was also being sent
   on PUT calls where it is ignored. Fixed by removing ~has_catchall~ from
   ~DEFAULT_DOMAIN_SETTINGS~ and passing ~"catchall": False~ explicitly in the
   creation POST only. New domains will no longer acquire a catch-all.

2. *Bidirectional alias sync*: ~provider_enable_email_accounts_for_server~
   was renamed to ~provider_sync_server_aliases~ and reworked to do a full
   bidirectional sync. When called with ~enabled=True~ (normal hourly sync) it
   now deletes any alias on the provider that has no corresponding local
   ~EmailAccount~. The catch-all (~"*@domain.com"~) has no local counterpart
   so it will be deleted automatically on the next hourly run.
   When called with ~enabled=False~ (provider removed from server) it deletes
   all aliases on the provider.

This fixes GH-204