### PR TITLE
Clear cache on Server deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-05-08
+
+### Fixed
+
+- Fix stale Redis cache causing 404 errors when a Server is recreated after being deleted from forwardemail.net — evict domain and alias cache entries when a Server is deleted from Django
+
 ## [0.7.4] - 2026-05-08
 
 ### Fixed

--- a/app/as_email/providers/base.py
+++ b/app/as_email/providers/base.py
@@ -402,6 +402,20 @@ class ProviderBackend(ABC):
 
     ####################################################################
     #
+    def on_server_deleted(self, server: "Server") -> None:  # noqa: B027
+        """
+        Called when a Server is deleted from Django so the backend can
+        clean up any locally cached state (e.g. Redis domain ID entries).
+
+        The default implementation is a no-op.  Providers that maintain a
+        local cache of remote IDs should override this to evict stale entries.
+
+        Args:
+            server: The Server instance being deleted
+        """
+
+    ####################################################################
+    #
     @abstractmethod
     def create_email_account(self, email_account: "EmailAccount") -> None:
         """

--- a/app/as_email/providers/forwardemail.py
+++ b/app/as_email/providers/forwardemail.py
@@ -1436,6 +1436,27 @@ class ForwardEmailBackend(ProviderBackend):
 
     ####################################################################
     #
+    def on_server_deleted(self, server: "Server") -> None:
+        """
+        Evict all Redis cache entries for a server and its email accounts.
+
+        Called from the Server pre_delete signal so that stale IDs are
+        gone before any re-creation attempt.  The domain entry and every
+        alias entry for each EmailAccount on the server are removed.
+
+        Args:
+            server: The Server instance being deleted
+        """
+        self.cache.delete_domain(server.domain_name)
+        for ea in server.email_accounts.all():
+            self.cache.delete_alias(ea.email_address)
+        logger.debug(
+            "Evicted forwardemail.net cache for deleted server '%s'",
+            server.domain_name,
+        )
+
+    ####################################################################
+    #
     def get_bounce_webhook_url(self, server: "Server") -> str:
         """
         Construct the domain-level bounce webhook URL for a server.

--- a/app/as_email/signals.py
+++ b/app/as_email/signals.py
@@ -18,6 +18,7 @@ from django.db.models.signals import (
     m2m_changed,
     post_delete,
     post_save,
+    pre_delete,
     pre_save,
 )
 from django.dispatch import receiver
@@ -421,3 +422,26 @@ def handle_receive_providers_changed(
                         )
                     )
                 )
+
+
+####################################################################
+#
+@receiver(pre_delete, sender=Server)
+def clear_provider_cache_on_server_delete(
+    sender: type[Server], instance: Server, **kwargs
+) -> None:
+    """
+    When a Server is deleted, evict its domain and all alias cache entries
+    from every associated provider backend.
+
+    Uses pre_delete so that instance.receive_providers and
+    instance.emailaccount_set are still accessible before cascade deletion
+    removes the related rows.
+    """
+    providers = set()
+    if instance.send_provider:
+        providers.add(instance.send_provider)
+    providers.update(instance.receive_providers.all())
+
+    for provider in providers:
+        provider.backend.on_server_deleted(instance)

--- a/app/as_email/tests/providers/test_forwardemail.py
+++ b/app/as_email/tests/providers/test_forwardemail.py
@@ -1092,6 +1092,41 @@ class TestForwardEmailAPIMethods:
 
     ####################################################################
     #
+    def test_on_server_deleted_clears_domain_and_alias_cache(
+        self,
+        server_factory: Callable[..., Server],
+        email_account_factory: Callable[..., EmailAccount],
+        use_fakeredis: redis.StrictRedis,
+        faker: Faker,
+    ) -> None:
+        """
+        GIVEN: a server with two email accounts whose domain and alias IDs
+               are all present in the Redis cache
+        WHEN:  on_server_deleted() is called
+        THEN:  the domain cache entry and both alias cache entries are evicted
+               and no API calls are made
+        """
+        backend = ForwardEmailBackend()
+        server = server_factory()
+        ea1 = email_account_factory(server=server)
+        ea2 = email_account_factory(server=server)
+
+        domain_key = f"forwardemail:domain:{server.domain_name}"
+        alias_key1 = f"forwardemail:alias:{ea1.email_address}"
+        alias_key2 = f"forwardemail:alias:{ea2.email_address}"
+
+        use_fakeredis.set(domain_key, faker.uuid4())
+        use_fakeredis.set(alias_key1, faker.uuid4())
+        use_fakeredis.set(alias_key2, faker.uuid4())
+
+        backend.on_server_deleted(server)
+
+        assert use_fakeredis.get(domain_key) is None
+        assert use_fakeredis.get(alias_key1) is None
+        assert use_fakeredis.get(alias_key2) is None
+
+    ####################################################################
+    #
     def test_create_email_account(
         self,
         email_account_factory: Callable[..., EmailAccount],

--- a/app/as_email/tests/test_signals.py
+++ b/app/as_email/tests/test_signals.py
@@ -388,6 +388,29 @@ class TestProviderSignals:
 
     ####################################################################
     #
+    def test_clear_provider_cache_on_server_delete_calls_on_server_deleted(
+        self,
+        server_factory: Callable[..., Server],
+        mocker: MockerFixture,
+    ) -> None:
+        """
+        GIVEN: a server with a send_provider that is also a receive_provider
+        WHEN:  the server is deleted
+        THEN:  on_server_deleted is called on the provider backend exactly once
+               (send and receive share the same provider, so deduplication applies)
+        """
+        server = server_factory()
+        assert server.send_provider is not None
+        mock_hook = mocker.patch.object(
+            server.send_provider.backend, "on_server_deleted"
+        )
+
+        server.delete()
+
+        mock_hook.assert_called_once_with(server)
+
+    ####################################################################
+    #
     def test_handle_send_provider_changed_does_not_fire_on_unrelated_save(
         self,
         server_factory: Callable[..., Server],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "as-email-service"
-version = "0.7.4"
+version = "0.7.5"
 description = "Apricot Systematic Email Service"
 requires-python = ">=3.13.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "as-email-service"
-version = "0.7.3"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Yup. One of the hardest problems. Caching. Following on from the previous fix - we need to clear the Provider cache when we delete a Server.