### PR TITLE
Fix dropping messages when sent to multiple recipients on the same domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-07
+
+### Fixed
+
+- ForwardEmail: a message sent to multiple accounts in the same domain is now delivered to all of them. Every alias's incoming webhook URL now includes a unique `recipient` parameter, preventing forwardemail.net's duplicate-delivery suppression (keyed on message fingerprint + webhook URL) from silently dropping copies for all but the first recipient when the message arrives in separate SMTP transactions
+
 ## [0.9.0] - 2026-07-05
 
 ### Added

--- a/app/as_email/providers/forwardemail.py
+++ b/app/as_email/providers/forwardemail.py
@@ -20,6 +20,12 @@ flow is:
 Because the webhook URL is stored per-alias, ``create_update_email_account``
 always includes it when creating or updating an alias via the API.
 
+NOTE: Each alias's webhook URL MUST be unique (we append a ``recipient``
+query parameter to guarantee this).  forwardemail.net suppresses repeat
+deliveries keyed on message fingerprint + webhook URL for one day, so two
+aliases sharing one URL would lose mail whenever a single message is sent
+to both addresses in separate SMTP transactions.  See ``get_webhook_url``.
+
 **Outbound mail**
 
 Outbound email is sent via the ``/v1/emails`` REST API endpoint using the
@@ -1029,7 +1035,7 @@ class ForwardEmailBackend(ProviderBackend):
             delivered_count += 1
 
             logger.info(
-                "deliver_email_locally: Queued delivery for '%s', message %s, from %s",
+                "Queued '%s', message %s, from %s",
                 recipient,
                 message_id,
                 from_addr_str,
@@ -1501,11 +1507,23 @@ class ForwardEmailBackend(ProviderBackend):
         """
         Construct the incoming webhook URL for an email account.
 
+        The URL includes a ``recipient`` query parameter with the account's
+        email address so that every alias has a *unique* webhook URL.
+
+        IMPORTANT: forwardemail.net deduplicates deliveries by message
+        fingerprint (Message-ID/Date/From/To/Cc/Subject) plus webhook URL,
+        with a 1-day TTL.  If two aliases shared an identical webhook URL, a
+        message sent to both addresses in separate SMTP transactions would
+        only trigger a webhook for the first one - the second delivery would
+        be silently marked as accepted and dropped.  The ``recipient``
+        parameter exists solely to keep the URLs distinct per alias; the
+        webhook view itself ignores it.
+
         Args:
             email_account: The EmailAccount to get the webhook URL for
 
         Returns:
-            The full webhook URL with api_key query parameter
+            The full webhook URL with api_key and recipient query parameters
         """
         # Get the base incoming webhook URL for this provider
         #
@@ -1523,7 +1541,7 @@ class ForwardEmailBackend(ProviderBackend):
         webhook_url_base = urljoin(base_url, webhook_path)
         webhook_url = (
             f"{webhook_url_base}?"
-            f"{urlencode({'api_key': email_account.server.api_key})}"
+            f"{urlencode({'api_key': email_account.server.api_key, 'recipient': email_account.email_address})}"
         )
 
         return webhook_url

--- a/app/tests/as_email/providers/test_forwardemail.py
+++ b/app/tests/as_email/providers/test_forwardemail.py
@@ -567,7 +567,7 @@ class TestForwardEmailBackend:
         )
 
         # Verify logging
-        assert "deliver_email_locally: Queued delivery for" in caplog.text
+        assert "Queued " in caplog.text
         assert email_account.email_address in caplog.text
         assert message_id in caplog.text
         assert from_email in caplog.text
@@ -627,9 +627,7 @@ class TestForwardEmailBackend:
         assert nonexistent_email in response_data["failed_recipients"]
 
         # Verify logging - should have two successful deliveries
-        assert (
-            caplog.text.count("deliver_email_locally: Queued delivery for") == 2
-        )
+        assert caplog.text.count("Queued ") == 2
         assert account1.email_address in caplog.text
         assert account2.email_address in caplog.text
         assert "EmailAccount that does not exist" in caplog.text
@@ -680,7 +678,7 @@ class TestForwardEmailBackend:
         assert response_data["delivered"] == 1
 
         # Verify logging shows the hash address was used
-        assert "deliver_email_locally: Queued delivery for" in caplog.text
+        assert "Queued " in caplog.text
         assert hash_addr in caplog.text
 
 
@@ -727,6 +725,68 @@ class TestForwardEmailAPIMethods:
         )
 
         assert backend.get_bounce_webhook_url(server) == expected_url
+
+    ####################################################################
+    #
+    def test_get_webhook_url(
+        self,
+        server_factory: Callable[..., Server],
+        email_account_factory: Callable[..., EmailAccount],
+    ) -> None:
+        """
+        GIVEN: an email account
+        WHEN:  get_webhook_url is called
+        THEN:  the returned URL exactly matches the hook_incoming URL for
+               this provider and domain, prefixed with https://SITE_NAME,
+               carrying both api_key and recipient query parameters
+        """
+        backend = ForwardEmailBackend()
+        server = server_factory()
+        email_account = email_account_factory(server=server)
+
+        expected_path = reverse(
+            "as_email:hook_incoming",
+            kwargs={
+                "provider_name": "forwardemail",
+                "domain_name": server.domain_name,
+            },
+        )
+        query = urlencode(
+            {
+                "api_key": server.api_key,
+                "recipient": email_account.email_address,
+            }
+        )
+        expected_url = f"https://{settings.SITE_NAME}{expected_path}?{query}"
+
+        assert backend.get_webhook_url(email_account) == expected_url
+
+    ####################################################################
+    #
+    def test_get_webhook_url_unique_per_email_account(
+        self,
+        server_factory: Callable[..., Server],
+        email_account_factory: Callable[..., EmailAccount],
+    ) -> None:
+        """
+        GIVEN: two email accounts on the same server
+        WHEN:  get_webhook_url is called for each
+        THEN:  the two URLs must differ from each other
+
+        forwardemail.net suppresses repeat deliveries keyed on message
+        fingerprint + webhook URL (1-day TTL).  If two aliases shared an
+        identical webhook URL, a message sent to both addresses in separate
+        SMTP transactions would only trigger a webhook for the first one -
+        the second copy would be silently dropped.
+        """
+        backend = ForwardEmailBackend()
+        server = server_factory()
+        account1 = email_account_factory(server=server)
+        account2 = email_account_factory(server=server)
+
+        assert backend.get_webhook_url(account1) != backend.get_webhook_url(
+            account2
+        )
 
     ####################################################################
     #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "as-email-service"
-version = "0.9.0"
+version = "0.9.1"
 description = "Apricot Systematic Email Service"
 requires-python = ">=3.13.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "as-email-service"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Basically we need to have every alias registered with forwardemail.net be _unique_ per email address. So add the email address as a query parameter on the inbound web hook. We do not actually use the parameter, but it guarantees that forwardemail.net will call it once for every recipient if there is more than one recipient for a domain.