### PR TITLE
Fix squirrely encodes from euc-jp and shift_jis encoded email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-07-19
+
+### Fixed
+
+- Malformed email messages that Python's email generators can not serialize (e.g. 8-bit messages declaring a euc-jp/shift_jis charset, or non-ASCII content with no charset declaration) no longer fail local, IMAP, or spam-scan delivery with UnicodeEncodeError; all message serialization now goes through encoding-tolerant helpers
+- Incoming webhook requests larger than the request body limit now receive a 413 response instead of an unhandled 400 error; the limit was raised from 10MiB to 50MiB to match ForwardEmail's maximum message size
+
 ## [0.9.2] - 2026-07-16
 
 ### Fixed

--- a/app/as_email/deliver.py
+++ b/app/as_email/deliver.py
@@ -41,9 +41,7 @@ from mailbox import MH, ExternalClashError, NoSuchMailboxError
 # Project imports
 #
 from .models import EmailAccount, LocalDelivery, MessageFilterRule
-from .utils import get_spam_score
-
-ENCODINGS = ("ascii", "iso-8859-1", "utf-8")
+from .utils import get_spam_score, message_as_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -130,20 +128,7 @@ def _add_msg_to_folder(folder: MH, msg: EmailMessage):
     Adding a message to a MH folder requires several simple steps. This
     wraps those steps.
     """
-    # To deal with encoding snafus from whoever sent this message we try to
-    # encode it as bytes using several different encoders.
-    #
-    msg_bytes = None
-    msg_text = msg.as_string(policy=email.policy.default)
-    for encoding in ENCODINGS:
-        try:
-            msg_bytes = msg_text.encode(encoding)
-            break
-        except ValueError:
-            pass
-
-    if msg_bytes is None:
-        raise ValueError(f"Unable to encode message using any of {ENCODINGS}")
+    msg_bytes = message_as_bytes(msg)
 
     with lock_folder(folder):
         msg_id = int(folder.add(msg_bytes))

--- a/app/as_email/management/commands/aiosmtpd.py
+++ b/app/as_email/management/commands/aiosmtpd.py
@@ -54,7 +54,7 @@ from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from as_email.deliver import make_delivery_status_notification
 from as_email.models import EmailAccount, InactiveEmail, Server
 from as_email.tasks import dispatch_incoming_email
-from as_email.utils import msg_froms, write_spooled_email
+from as_email.utils import message_as_string, msg_froms, write_spooled_email
 
 SMTP_PORT = 25
 LISTEN_HOST = "0.0.0.0"
@@ -1079,7 +1079,7 @@ async def deliver_email_locally(
     #
     msg = email.message_from_bytes(msg_bytes, policy=email.policy.default)
     msg_id = msg.get("Message-ID", "unknown")
-    msg_str = msg.as_string(policy=email.policy.default)
+    msg_str = message_as_string(msg)
 
     # Get the a formatted list of all the 'from's for this message. Almost
     # always there will only be one from, but it is not specifically disallowed

--- a/app/as_email/models.py
+++ b/app/as_email/models.py
@@ -39,7 +39,7 @@ from postmarker.core import PostmarkClient
 # project imports
 #
 from .providers import get_backend
-from .utils import get_spam_score
+from .utils import get_spam_score, message_as_bytes
 
 # Various models that belong to a specific user need the User object.
 #
@@ -1467,13 +1467,7 @@ class ImapDelivery(DeliveryMethod):
             msg: The email message to deliver.
             visited_accounts: Unused for IMAP delivery; required by interface.
         """
-        # Use as_string() + encode() instead of as_bytes() to avoid
-        # UnicodeEncodeError on malformed messages with non-ASCII content
-        # but no charset declaration.  as_string() returns a Python str
-        # (Unicode), sidestepping the ASCII-only serialization in
-        # as_bytes().
-        #
-        msg_bytes = msg.as_string(policy=email.policy.default).encode("utf-8")
+        msg_bytes = message_as_bytes(msg)
 
         with imapclient.IMAPClient(
             host=self.imap_host, port=self.imap_port, ssl=True

--- a/app/as_email/providers/forwardemail.py
+++ b/app/as_email/providers/forwardemail.py
@@ -106,6 +106,8 @@ from as_email.models import EmailAccount
 from as_email.provider_tokens import get_provider_token
 from as_email.tasks import dispatch_incoming_email, process_bounce
 from as_email.utils import (
+    message_as_bytes,
+    message_as_string,
     now_str_datetime,
     redis_client,
     split_email_mailbox_hash,
@@ -859,7 +861,7 @@ class ForwardEmailBackend(ProviderBackend):
         Raises:
             HTTPError: For non-retryable provider errors (e.g. 400, 422)
         """
-        data = {"raw": message.as_string(policy=email.policy.SMTP)}
+        data = {"raw": message_as_string(message, policy=email.policy.SMTP)}
         try:
             self.api.req(HTTPMethod.POST, "v1/emails", data=data)
             return True
@@ -878,7 +880,9 @@ class ForwardEmailBackend(ProviderBackend):
                 )
                 if spool_on_retryable:
                     assert server.outgoing_spool_dir is not None
-                    spool_message(server.outgoing_spool_dir, message.as_bytes())
+                    spool_message(
+                        server.outgoing_spool_dir, message_as_bytes(message)
+                    )
                 return False
             logger.error(
                 "Failed to send email via %s: %d %s",

--- a/app/as_email/providers/postmark.py
+++ b/app/as_email/providers/postmark.py
@@ -38,6 +38,7 @@ from ..tasks import (
 from ..utils import (
     BOUNCE_TYPES_BY_TYPE_CODE,
     get_smtp_client,
+    message_as_bytes,
     msg_froms,
     sendmail,
     split_email_mailbox_hash,
@@ -172,7 +173,9 @@ class PostmarkBackend(ProviderBackend):
             )
             if spool_on_retryable:
                 assert server.outgoing_spool_dir is not None
-                spool_message(server.outgoing_spool_dir, message.as_bytes())
+                spool_message(
+                    server.outgoing_spool_dir, message_as_bytes(message)
+                )
             return False
         finally:
             smtp_client.quit()
@@ -218,7 +221,9 @@ class PostmarkBackend(ProviderBackend):
             )
             if spool_on_retryable:
                 assert server.outgoing_spool_dir is not None
-                spool_message(server.outgoing_spool_dir, message.as_bytes())
+                spool_message(
+                    server.outgoing_spool_dir, message_as_bytes(message)
+                )
             return False
         except ClientError as exc:
             # For certain error codes we spool for retry. For everything else
@@ -231,7 +236,9 @@ class PostmarkBackend(ProviderBackend):
             ):
                 if spool_on_retryable:
                     assert server.outgoing_spool_dir is not None
-                    spool_message(server.outgoing_spool_dir, message.as_bytes())
+                    spool_message(
+                        server.outgoing_spool_dir, message_as_bytes(message)
+                    )
                     logger.warning("Spooling message for retry (%r)", exc)
                 else:
                     logger.warning("Message retry failed: (%r)", exc)

--- a/app/as_email/tasks.py
+++ b/app/as_email/tasks.py
@@ -42,6 +42,7 @@ from .providers.base import BounceEvent, BounceType, Capability
 from .reports import REPORTS, ReportSchedule, get_reports_by_schedule
 from .utils import (
     PWUser,
+    message_as_bytes,
     read_emailaccount_pwfile,
     redis_client,
     write_emailaccount_pwfile,
@@ -603,11 +604,7 @@ def scan_message_for_spam(
         message when the scan fails.
     """
     try:
-        # Use as_string() + encode() instead of as_bytes() to avoid
-        # UnicodeEncodeError on malformed messages with non-ASCII content
-        # but no charset declaration.
-        #
-        msg_bytes = msg.as_string(policy=email.policy.default).encode("utf-8")
+        msg_bytes = message_as_bytes(msg)
 
         # NOTE: Use new_event_loop() + run_until_complete() instead of
         # asyncio.run() to avoid touching the global event loop policy.

--- a/app/as_email/utils.py
+++ b/app/as_email/utils.py
@@ -212,6 +212,78 @@ def split_email_mailbox_hash(email_address: str) -> tuple[str, str | None]:
 
 ####################################################################
 #
+def message_as_bytes(
+    msg: EmailMessage, policy: email.policy.Policy = email.policy.default
+) -> bytes:
+    """
+    Serialize an email message to bytes, tolerating malformed messages.
+
+    Messages from the wild are frequently malformed in ways that make one
+    of the email package's generators raise UnicodeEncodeError:
+
+    - as_bytes() fails on messages with non-ASCII text content but no
+      charset declaration (the payload can not be encoded as ascii).
+    - as_string() fails on messages whose undecodable bytes were parsed
+      into surrogate-escaped characters and whose declared charset is
+      re-encoded by the generator (eg: a euc-jp or shift_jis text part is
+      re-encoded through iso-2022-jp, which can never encode surrogates).
+
+    These failure modes are complementary, so try as_bytes() first -- it
+    reproduces the original message bytes exactly as received -- and fall
+    back to as_string() for the messages as_bytes() can not handle.
+
+    Args:
+        msg: The email message to serialize.
+        policy: The email policy to serialize with.
+
+    Returns:
+        The serialized message as bytes.
+    """
+    try:
+        return msg.as_bytes(policy=policy)
+    except (UnicodeError, LookupError):
+        pass
+    # NOTE: 'surrogateescape' turns any surrogate-escaped characters in the
+    #       generated string back into the raw bytes of the original message
+    #       instead of raising UnicodeEncodeError.
+    #
+    return msg.as_string(policy=policy).encode(
+        "utf-8", errors="surrogateescape"
+    )
+
+
+####################################################################
+#
+def message_as_string(
+    msg: EmailMessage, policy: email.policy.Policy = email.policy.default
+) -> str:
+    """
+    Serialize an email message to a str, tolerating malformed messages.
+
+    The str counterpart of message_as_bytes() -- see its docstring for the
+    two complementary generator failure modes. Tries as_string() first and
+    falls back to as_bytes() decoded with 'surrogateescape' so undecodable
+    bytes in the original message survive as surrogate-escaped characters.
+    The result can be written to json (json.dumps escapes the surrogates)
+    and encoding it with 'utf-8'/'surrogateescape' restores the original
+    bytes.
+
+    Args:
+        msg: The email message to serialize.
+        policy: The email policy to serialize with.
+
+    Returns:
+        The serialized message as a str.
+    """
+    try:
+        return msg.as_string(policy=policy)
+    except (UnicodeError, LookupError):
+        pass
+    return msg.as_bytes(policy=policy).decode("utf-8", errors="surrogateescape")
+
+
+####################################################################
+#
 # XXX Should we make this an async function since it writes a file? Or at least
 #     make an async equivalent.
 #
@@ -228,11 +300,7 @@ def write_spooled_email(
     spool message and meta information was written to (as json).
     """
     spool_dir = spool_dir if isinstance(spool_dir, Path) else Path(spool_dir)
-    msg = (
-        msg
-        if isinstance(msg, str)
-        else msg.as_string(policy=email.policy.default)
-    )
+    msg = msg if isinstance(msg, str) else message_as_string(msg)
     msg_id = msg_id if msg_id is not None else make_msgid(recipient)
     msg_date = (
         msg_date

--- a/app/as_email/views.py
+++ b/app/as_email/views.py
@@ -22,7 +22,7 @@ import xml.etree.ElementTree as ET
 #
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, RequestDataTooBig
 from django.db.models import Count, Prefetch, Q
 from django.http import (
     Http404,
@@ -296,7 +296,22 @@ def hook_incoming(request, provider_name: str, domain_name: str):
             f"Provider '{provider_name}' does not support incoming webhooks"
         )
 
-    return provider.backend.handle_incoming_webhook(request, server)
+    # NOTE: RequestDataTooBig is raised when the provider backend reads
+    #       request.body and it exceeds DATA_UPLOAD_MAX_MEMORY_SIZE. Return a
+    #       413 so the provider knows the message was too large instead of
+    #       letting the error propagate as an unhandled 400.
+    #
+    try:
+        return provider.backend.handle_incoming_webhook(request, server)
+    except RequestDataTooBig:
+        logger.warning(
+            "Incoming webhook for %s via %s: request body exceeds "
+            "DATA_UPLOAD_MAX_MEMORY_SIZE (%d)",
+            domain_name,
+            provider_name,
+            settings.DATA_UPLOAD_MAX_MEMORY_SIZE,
+        )
+        return HttpResponse("Request body too large", status=413)
 
 
 ####################################################################

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -226,7 +226,11 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
-DATA_UPLOAD_MAX_MEMORY_SIZE = 10_485_760  # 10mib
+# NOTE: Sized to ForwardEmail's 50mb maximum message size -- incoming
+#       webhooks deliver the entire message base64 encoded inside a json
+#       body, so the request body can be as large as the provider's limit.
+#
+DATA_UPLOAD_MAX_MEMORY_SIZE = 52_428_800  # 50mib
 REST_FRAMEWORK = {
     # All access to the as_email API requires authentication. Additional
     # permissions are defined on each of the models.

--- a/app/tests/as_email/test_deliver.py
+++ b/app/tests/as_email/test_deliver.py
@@ -105,6 +105,46 @@ def test_deliver_message_locally(
 
 ####################################################################
 #
+@pytest.mark.parametrize(
+    "fixture_name,marker",
+    [
+        # as_string() raises UnicodeEncodeError: the declared charset
+        # (euc-jp -> iso-2022-jp) can not encode the surrogate-escaped
+        # payload (AS-EMAIL-SERVICE-3S).
+        #
+        ("undecodable_charset_email", b"Hello from a broken mailer"),
+        # as_bytes() raises UnicodeEncodeError: non-ASCII content with no
+        # charset declaration.
+        #
+        ("malformed_non_ascii_email", b"special"),
+    ],
+)
+def test_deliver_message_locally_malformed_encoding(
+    request: pytest.FixtureRequest,
+    email_account_factory: Callable[..., EmailAccount],
+    fixture_name: str,
+    marker: bytes,
+) -> None:
+    """
+    GIVEN a malformed message that the email generators can not serialize
+          via as_string() or as_bytes()
+    WHEN  the message is delivered locally
+    THEN  it is stored in the inbox instead of raising UnicodeEncodeError
+    """
+    ea = email_account_factory()
+    ld = LocalDelivery.objects.get(email_account=ea)
+    msg = request.getfixturevalue(fixture_name)
+
+    deliver_message_locally(ld, msg)
+
+    mh = ld.MH()
+    folder = mh.get_folder("inbox")
+    assert len(folder.keys()) == 1
+    assert marker in folder.get_bytes(str(1))
+
+
+####################################################################
+#
 def test_deliver_spam_locally(
     email_account_factory: Callable[..., EmailAccount],
     email_factory: Callable[..., EmailMessage],

--- a/app/tests/as_email/test_delivery_methods.py
+++ b/app/tests/as_email/test_delivery_methods.py
@@ -680,25 +680,43 @@ class TestImapDeliveryModel:
 
     ####################################################################
     #
-    def test_deliver_non_ascii_message(
+    @pytest.mark.parametrize(
+        "fixture_name,marker",
+        [
+            # Non-ASCII content but no charset declaration: as_bytes()
+            # raises UnicodeEncodeError on this (common in spam).
+            #
+            ("malformed_non_ascii_email", b"special"),
+            # Undecodable bytes with a declared charset (euc-jp):
+            # as_string() raises UnicodeEncodeError on this
+            # (AS-EMAIL-SERVICE-3S).
+            #
+            ("undecodable_charset_email", b"Hello from a broken mailer"),
+        ],
+    )
+    def test_deliver_malformed_message(
         self,
+        request: pytest.FixtureRequest,
         imap_delivery_factory: Callable[..., ImapDelivery],
-        malformed_non_ascii_email: EmailMessage,
         mocker: MockerFixture,
+        fixture_name: str,
+        marker: bytes,
     ) -> None:
         """
-        GIVEN a malformed email with non-ASCII characters in the subject
-              and body but no charset declaration (common in spam)
+        GIVEN a malformed email that as_string() or as_bytes() can not
+              serialize
         WHEN  deliver() is called
         THEN  the message is serialized and appended without raising
               UnicodeEncodeError
         """
         mock_cls = mocker.patch("as_email.models.imapclient.IMAPClient")
         mock_client = mock_cls.return_value.__enter__.return_value
+        msg = request.getfixturevalue(fixture_name)
 
         imap_d = imap_delivery_factory()
-        imap_d.deliver(malformed_non_ascii_email, set())
+        imap_d.deliver(msg, set())
 
         mock_client.append.assert_called_once()
         appended_bytes = mock_client.append.call_args[0][1]
         assert isinstance(appended_bytes, bytes)
+        assert marker in appended_bytes

--- a/app/tests/as_email/test_tasks.py
+++ b/app/tests/as_email/test_tasks.py
@@ -316,14 +316,28 @@ def test_scan_message_for_spam_failure(
 
 ####################################################################
 #
-def test_scan_message_for_spam_non_ascii(
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        # Non-ASCII content but no charset declaration: as_bytes() raises
+        # UnicodeEncodeError on this (common in spam).
+        #
+        "malformed_non_ascii_email",
+        # Undecodable bytes with a declared charset (euc-jp): as_string()
+        # raises UnicodeEncodeError on this (AS-EMAIL-SERVICE-3S).
+        #
+        "undecodable_charset_email",
+    ],
+)
+def test_scan_message_for_spam_malformed(
+    request: pytest.FixtureRequest,
     mocker: MockerFixture,
-    malformed_non_ascii_email: EmailMessage,
     caplog: LogCaptureFixture,
+    fixture_name: str,
 ) -> None:
     """
-    GIVEN a malformed message with non-ASCII content but no charset
-          declaration (common in spam)
+    GIVEN a malformed message that as_string() or as_bytes() can not
+          serialize
     WHEN  scan_message_for_spam is called
     THEN  the message is serialized to spamd without UnicodeEncodeError
     """
@@ -337,8 +351,9 @@ def test_scan_message_for_spam_non_ascii(
         new_callable=AsyncMock,
         return_value=mock_result,
     )
+    msg = request.getfixturevalue(fixture_name)
 
-    result = scan_message_for_spam(malformed_non_ascii_email)
+    result = scan_message_for_spam(msg)
 
     assert result["X-Spam-Score"] == "9.0"
     assert "Spam scan failed" not in caplog.text

--- a/app/tests/as_email/test_utils.py
+++ b/app/tests/as_email/test_utils.py
@@ -6,12 +6,14 @@ Test various functions in the utils module
 
 # system imports
 #
+import email.policy
 import json
 from datetime import UTC, datetime
 from pathlib import Path
 
 # 3rd party imports
 #
+import pytest
 from django.conf import LazySettings
 from django.contrib.auth.hashers import make_password
 from faker import Faker
@@ -20,6 +22,8 @@ from faker import Faker
 #
 from as_email.utils import (
     PWUser,
+    message_as_bytes,
+    message_as_string,
     now_str_datetime,
     read_emailaccount_pwfile,
     split_email_mailbox_hash,
@@ -27,6 +31,62 @@ from as_email.utils import (
     write_emailaccount_pwfile,
     write_spooled_email,
 )
+
+
+####################################################################
+#
+@pytest.mark.parametrize(
+    "fixture_name,marker",
+    [
+        # A well formed message; both native serializations work and the
+        # helpers must match them exactly.
+        #
+        ("email_factory", "A well formed message"),
+        # as_string() raises UnicodeEncodeError on this one: surrogate
+        # escaped payload with a declared charset (euc-jp) that gets
+        # re-encoded through iso-2022-jp (AS-EMAIL-SERVICE-3S).
+        #
+        ("undecodable_charset_email", "Hello from a broken mailer"),
+        # as_bytes() raises UnicodeEncodeError on this one: non-ASCII
+        # content with no charset declaration.
+        #
+        ("malformed_non_ascii_email", "special"),
+    ],
+)
+def test_message_serialization(
+    request: pytest.FixtureRequest, fixture_name: str, marker: str
+) -> None:
+    """
+    GIVEN an email message, well formed or malformed in a way that
+          as_string() or as_bytes() can not serialize
+    WHEN  serialized with message_as_bytes / message_as_string
+    THEN  serialization succeeds, preserves the message content, matches
+          the email package's own serialization whenever that works, and
+          the string form can be embedded in json (as write_spooled_email
+          does)
+    """
+    msg = request.getfixturevalue(fixture_name)
+    if callable(msg):
+        msg = msg(subject=marker)
+
+    msg_bytes = message_as_bytes(msg)
+    msg_str = message_as_string(msg)
+
+    # Whenever the native serialization works, the helper must produce
+    # identical output.
+    #
+    try:
+        assert msg_bytes == msg.as_bytes(policy=email.policy.default)
+    except UnicodeEncodeError:
+        pass
+    try:
+        assert msg_str == msg.as_string(policy=email.policy.default)
+    except UnicodeEncodeError:
+        pass
+
+    assert marker.encode() in msg_bytes
+    assert marker in msg_str
+    assert json.dumps({"raw_email": msg_str})
 
 
 ####################################################################

--- a/app/tests/as_email/test_views.py
+++ b/app/tests/as_email/test_views.py
@@ -16,7 +16,8 @@ from urllib.parse import urlencode, urlparse
 #
 import pytest
 from dirty_equals import IsPartialDict
-from django.http import JsonResponse
+from django.conf import LazySettings
+from django.http import HttpRequest, JsonResponse
 from django.urls import resolve, reverse
 from faker import Faker
 from pytest_mock import MockerFixture
@@ -272,6 +273,53 @@ def test_incoming_webhook(
     mock_provider.backend.handle_incoming_webhook.assert_called_once()
     call_args = mock_provider.backend.handle_incoming_webhook.call_args
     assert call_args[0][1] == server  # Second argument should be the server
+
+
+####################################################################
+#
+def test_incoming_webhook_too_big_returns_413(
+    email_account_factory: Callable[..., EmailAccount],
+    api_client: type[APIClient],
+    mock_webhook_provider: Callable,
+    settings: LazySettings,
+) -> None:
+    """
+    GIVEN a webhook POST whose body exceeds DATA_UPLOAD_MAX_MEMORY_SIZE
+    WHEN  the provider backend tries to read request.body
+    THEN  the view returns a 413 instead of an unhandled RequestDataTooBig
+          error (AS-EMAIL-SERVICE-3K)
+    """
+    ea = email_account_factory()
+    ea.save()
+    server = ea.server
+    settings.DATA_UPLOAD_MAX_MEMORY_SIZE = 1024
+
+    # The provider backend reads request.body, which is what raises
+    # RequestDataTooBig when the body exceeds the limit.
+    #
+    def read_body(request: HttpRequest, server: Server) -> JsonResponse:
+        _ = request.body
+        return JsonResponse({"status": "all good"})
+
+    mock_provider = mock_webhook_provider("handle_incoming_webhook", None)
+    mock_provider.backend.handle_incoming_webhook.side_effect = read_body
+
+    url = (
+        reverse(
+            "as_email:hook_incoming",
+            kwargs={
+                "provider_name": "dummy",
+                "domain_name": server.domain_name,
+            },
+        )
+        + "?"
+        + urlencode({"api_key": server.api_key})
+    )
+
+    client = api_client()
+    r = client.post(url, "x" * 2048, content_type="application/json")
+
+    assert r.status_code == 413
 
 
 ####################################################################

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -244,6 +244,32 @@ def malformed_non_ascii_email() -> EmailMessage:
 ####################################################################
 #
 @pytest.fixture
+def undecodable_charset_email() -> EmailMessage:
+    """
+    An email whose text part contains bytes that can not be decoded and
+    declares a charset (euc-jp) that the email generator re-encodes through
+    iso-2022-jp.  Mimics real spam messages that cause UnicodeEncodeError
+    ('iso2022_jp' codec can not encode character '\\udcef') when serialized
+    with as_string(policy=default) because the generator re-encodes the
+    surrogate-escaped payload with the declared charset (see
+    AS-EMAIL-SERVICE-3S).
+    """
+    raw = (
+        b"From: sender@example.com\n"
+        b"To: recipient@example.com\n"
+        b"Subject: undecodable bytes\n"
+        b"MIME-Version: 1.0\n"
+        b"Content-Type: text/plain; charset=euc-jp\n"
+        b"Content-Transfer-Encoding: 8bit\n"
+        b"\n"
+        b"\xef\xbb\xbfHello from a broken mailer\n"
+    )
+    return email.message_from_bytes(raw, policy=email.policy.default)
+
+
+####################################################################
+#
+@pytest.fixture
 def email_account_factory(
     server_factory: Callable[..., Server], settings: LazySettings, faker: Faker
 ) -> Iterator[Callable[..., EmailAccount]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "as-email-service"
-version = "0.9.2"
+version = "0.9.3"
 description = "Apricot Systematic Email Service"
 requires-python = ">=3.13.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ wheels = [
 
 [[package]]
 name = "as-email-service"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Also raise inconming email limit from 10MiB to 50MiB. Also move the “as string” and “as bytes” in to utility functions so we can use the same logic everywhere.